### PR TITLE
Added example using dynamic_service_client

### DIFF
--- a/python/client/dynamic_imports_test.py
+++ b/python/client/dynamic_imports_test.py
@@ -1,0 +1,36 @@
+from snet.sdk import SnetSDK
+
+from config import config
+
+sdk = SnetSDK(config)
+
+org_id = "snet"
+service_id = "example-service"
+
+service_client = sdk.create_dynamic_service_client(org_id, service_id)
+
+
+# Examples using the "get_method" utility function
+method, request_type, _ = service_client.get_method("add")
+request = request_type(a=20, b=3)
+print("Performing {} + {}:".format(request.a, request.b))
+result = method(request)
+print("Result: {}".format(result.value))
+
+# Example using the "get_method" utility function and a fully qualified method name ([<package>].service.method)
+method, request_type, _ = service_client.get_method("example_service.Calculator.mul")
+request = request_type(a=7, b=12)
+print("Performing {} * {}:".format(request.a, request.b))
+result = method(request)
+print("Result: {}".format(result.value))
+
+
+# Examples without the get_method utility function
+request = service_client.example_service.message.Numbers(a=17, b=12)
+print("Performing {} - {}:".format(request.a, request.b))
+result = service_client.example_service.service.Calculator.service.sub(request)
+print("Result: {}".format(result.value))
+
+print("Performing {} / {}:".format(request.a, request.b))
+result = service_client.example_service.service.Calculator.service.div(request)
+print("Result: {}".format(result.value))


### PR DESCRIPTION
Examples using the create_dynamic_service_client method which downloads and compiles the protobuf files for the user given an ord_id and a service_id.

The examples use two approaches:
- Using the convenience get_method function to automatically get the method function for the desired call and it's request and response types
- Getting the method function and the message types directly from the DynamicServiceClient instance manually